### PR TITLE
Fix rc notification component

### DIFF
--- a/app/src/components/ErrorAlert/index.js
+++ b/app/src/components/ErrorAlert/index.js
@@ -3,7 +3,7 @@ import styles from './index.module.scss';
 import cssModules from 'react-css-modules';
 import Notification from 'grommet/components/Notification';
 import CloseIcon from 'grommet/components/icons/base/Close';
-import Button from 'grommet/components/button';
+import Button from 'grommet/components/Button';
 import Section from 'grommet/components/Section';
 
 const ErrorAlert = ({

--- a/app/src/components/ErrorAlert/index.js
+++ b/app/src/components/ErrorAlert/index.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import styles from './index.module.scss';
 import cssModules from 'react-css-modules';
-import Notification from 'grommet/components/notification';
+import Notification from 'grommet/components/Notification';
 import CloseIcon from 'grommet/components/icons/base/Close';
 import Button from 'grommet/components/button';
 import Section from 'grommet/components/Section';


### PR DESCRIPTION
All components from Grommet need to be imported with uppercase names for Linux compatibility.