### PR TITLE
Fix: remove the caret from webpack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "style-loader": "^0.13.0",
     "svg-react-loader": "^0.3.6",
     "utils": "^0.3.1",
-    "webpack": "^2.1.0-beta.19"
+    "webpack": "2.1.0-beta.19"
   },
   "devDependencies": {
     "all-contributors-cli": "^3.0.6",


### PR DESCRIPTION
Note: the webpack version is a beta version and it needs to be _exactly_ the version in the package.json

If you receive a build error, this is likely due to the wrong webpack version, so please try
```
npm install webpack@2.1.0-beta.19
```

This has been reflected in the package.json