### PR TITLE
Fix: implementing redirecting to articles/:id upon clicking title of each article 

### DIFF
--- a/app/src/components/DashboardTable/index.js
+++ b/app/src/components/DashboardTable/index.js
@@ -25,7 +25,7 @@ const DashboardTable = ({
         {articles.map((article, i) =>
           <TableRow key={i}>
             <td>
-              <Anchor href={`/admin/articles/${article.id}`}>
+              <Anchor href={`/articles/${article.id}`}>
                 {article.title.slice(0, 15)}
               </Anchor>
             </td>


### PR DESCRIPTION
implementing redirecting to articles/:id upon clicking title of each article on /admin/content-dashboard