### PR TITLE
Fix kb fix 404 page typo

### DIFF
--- a/app/src/containers/NotFoundContainer/index.js
+++ b/app/src/containers/NotFoundContainer/index.js
@@ -38,7 +38,7 @@ class NotFound extends Component { // eslint-disable-line react/prefer-stateless
           <Paragraph textAlign="center">
             { /* maybe could be smaller font. better would be no linebreak in here */ }
             You've wandered into uncharted territory. 404-Land.
-            <br />If that is right were you belong, then get ready to map!
+            <br />If that is right where you belong, then get ready to map!
           </Paragraph>
         </Box>
         <Box align="center">


### PR DESCRIPTION
Fixed a typo - changed 'were' to 'where' in this corrected sentence "If that is right where you belong, then get ready to map!"