### PR TITLE
fix: two words validation accepts accented chars

### DIFF
--- a/app/utils/validation.js
+++ b/app/utils/validation.js
@@ -1,6 +1,6 @@
 const isIntegerRE = /^\+?(0|[1-9]\d*)$/;
 const numberRE = /^(?=.*[0-9]).+$/;
-const twoWordsRE = /^[a-z]([-']?[a-z]+)*( [a-z]([-']?[a-z]+)*)+$/;
+const twoWordsRE = /^[a-z\u00C0-\u00FF]([-']?[a-z\u00C0-\u00FF]+)*( [a-z\u00C0-\u00FF]([-']?[a-z\u00C0-\u00FF]+)*)+$/;
 const lowercaseRE = /^(?=.*[a-z]).+$/;
 const uppercaseRE = /^(?=.*[A-Z]).+$/;
 const specialCharRE = /^(?=.*[_\W]).+$/;


### PR DESCRIPTION
Names can now contain accented latin characters, e.g. *Tamás*