### PR TITLE
fix: Update separator media query

### DIFF
--- a/app/src/components/AppFooter/index.module.scss
+++ b/app/src/components/AppFooter/index.module.scss
@@ -19,7 +19,7 @@
 .seperator {
   margin-left: 10px;
   margin-right: 10px;
-  @media screen and (max-width: 680px) {
+  @media screen and (max-width: 719px) {
     display: none;
   }
 }


### PR DESCRIPTION
Updated media query so separator (pipe character) does not show up
on its own line in footer from 681px to 719px width.
Fixes #151