### PR TITLE
Invalid Date Fix

### DIFF
--- a/app/src/components/ArticleCalendar/index.js
+++ b/app/src/components/ArticleCalendar/index.js
@@ -8,14 +8,14 @@ const ArticleCalendar = ({
 }) => (
   <div className={styles.articleCalendar}>
     <div className={styles.header}>
-      {moment(date).format('MMM')}
+      {moment(date, 'YYYY.MM.DD').format('MMM')}
     </div>
     <div className={styles.body}>
       <div className={styles.date}>
-        {moment(date).format('DD')}
+        {moment(date, 'YYYY.MM.DD').format('DD')}
       </div>
       <div className={styles.year}>
-        {moment(date).format('YYYY')}
+        {moment(date, 'YYYY.MM.DD').format('YYYY')}
       </div>
     </div>
   </div>

--- a/app/src/components/ArticleCalendar/index.js
+++ b/app/src/components/ArticleCalendar/index.js
@@ -8,14 +8,14 @@ const ArticleCalendar = ({
 }) => (
   <div className={styles.articleCalendar}>
     <div className={styles.header}>
-      {moment(date, 'YYYY.MM.DD').format('MMM')}
+      {moment(date, 'YYYY.MM.DD').utc().format('MMM')}
     </div>
     <div className={styles.body}>
       <div className={styles.date}>
-        {moment(date, 'YYYY.MM.DD').format('DD')}
+        {moment(date, 'YYYY.MM.DD').utc().format('DD')}
       </div>
       <div className={styles.year}>
-        {moment(date, 'YYYY.MM.DD').format('YYYY')}
+        {moment(date, 'YYYY.MM.DD').utc().format('YYYY')}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Implemented a fix for date time stamps being formatted as ‘Invalid Date’ in Safari and Firefox. Also setup the timestamps so they use UTC as their locale seeing as that’s what the API provides.

This PR fixes issue #163