### PR TITLE
Fix: address error after `yarn test` on Windows 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "t": "npm run test",
     "test:watch": "npm test -- --watch",
-    "test": "BABEL_DISABLE_CACHE=1 cross-env NODE_ENV='test' node --harmony_proxies node_modules/.bin/jest",
+    "test": "cross-env BABEL_DISABLE_CACHE=1 NODE_ENV='test' node --harmony_proxies ./node_modules/istanbul cover ./node_modules/.bin/jest",
     "build": "npm run ./node_modules/.bin/webpack",
     "dev": "./node_modules/.bin/webpack-dev-server",
     "generate": "all-contributors generate",


### PR DESCRIPTION
This is not a complete fix, therefore only serving as a demo. Please see [this issue](https://github.com/udacityalumni/alumni-client/issues/119).