### PR TITLE
Fix: add serializer to HTML util to protect against xss

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "resolve-url-loader": "^1.4.4",
     "rimraf": "^2.5.4",
     "sass-loader": "^3.1.2",
+    "serialize-javascript": "^1.3.0",
     "style-loader": "^0.13.0",
     "styled-components": "^1.0.11",
     "svg-react-loader": "^0.3.6",

--- a/server/utils/Html.js
+++ b/server/utils/Html.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import serialize from 'serialize-javascript';
 
 function Html({ content, state, scriptHash, cssHash, vendorHash, styles }) {
   return (
@@ -39,7 +40,9 @@ function Html({ content, state, scriptHash, cssHash, vendorHash, styles }) {
         <script src={`${scriptHash}`} charSet="UTF-8" />
         <script src={`${vendorHash}`} type="text/javascript" />
         <script
-          dangerouslySetInnerHTML={{ __html: `window.__APOLLO_STATE__=${JSON.stringify(state)};` }}
+          dangerouslySetInnerHTML={{
+            __html: `window.__APOLLO_STATE__=${serialize(state, { isJSON: true })};`,
+          }}
           charSet="UTF-8"
         />
       </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7227,6 +7227,10 @@ sentence-case@^1.1.1, sentence-case@^1.1.2:
   dependencies:
     lower-case "^1.1.1"
 
+serialize-javascript:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.3.0.tgz#86a4f3752f5c7e47295449b0bbb63d64ba533f05"
+
 serve-index@^1.7.2:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.8.0.tgz#7c5d96c13fb131101f93c1c5774f8516a1e78d3b"


### PR DESCRIPTION
See: https://medium.com/node-security/the-most-common-xss-vulnerability-in-react-js-applications-2bdffbcc1fa0#.uyz0ktc3p